### PR TITLE
Fix Xcode 10 compilation issue

### DIFF
--- a/Source/OpenLocationCode.swift
+++ b/Source/OpenLocationCode.swift
@@ -828,7 +828,7 @@ extension String {
     let range = Range(uncheckedBounds: (lower: lower, upper: upper))
     let start = index(startIndex, offsetBy: range.lowerBound)
     let end = index(start, offsetBy: range.upperBound - range.lowerBound)
-    return String(self[Range(start ..< end)])
+    return String(self[start ..< end])
   }
 
   /// Returns index of the first instance of the string, or -1 if not found.


### PR DESCRIPTION
Since 
https://github.com/apple/swift-evolution/blob/master/proposals/0143-conditional-conformances.md

All `Range`, `ClosedRange`, `CountableRange`, `CountableClosedRange` are merged in one `struct` so no need to pass range in initializer. And also `String[Range<String.Index>]` is backward compatible so should work in Xcode 9